### PR TITLE
Adds various enhancements

### DIFF
--- a/config/audits.php
+++ b/config/audits.php
@@ -4,6 +4,11 @@ return [
 
     'with_authenticated_user' => true,
 
+    // This will automatically add the audits column to the fillable array on all models that use MakesAudits
+    // If you want more control over which models set the audits column to fillable, set
+    // this to false and add the column to the fillable array on each model manually
+    'fillable_by_default' => false,
+
     'auth_models' => [
         'user' => [
             'model' => \App\User::class,

--- a/tests/MakesAuditsTest.php
+++ b/tests/MakesAuditsTest.php
@@ -4,9 +4,17 @@ namespace Zaengle\Audit\Tests;
 
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
 
 class MakesAuditsTest extends BaseTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('audits.fillable_by_default', true);
+    }
+
     /** @test */
     public function it_audits_a_new_model_on_creation()
     {
@@ -43,5 +51,19 @@ class MakesAuditsTest extends BaseTestCase
         $this->assertEquals($model->getKey(), Arr::get($model->audits[1], 'data.id'));
         $this->assertEquals('new', Arr::get($model->audits[1], 'data.name'));
         $this->assertEquals(now()->toDateTimeString(), Arr::get($model->audits[1], 'updated_at'));
+    }
+
+    /** @test */
+    public function it_makes_a_manual_audit()
+    {
+        $model = TestModel::create([
+            'name' => 'test',
+        ]);
+
+        $model->manualAudit(['name' => 'manual']);
+
+        $this->assertEquals($model->audits[1], [
+            'name' => 'manual',
+        ]);
     }
 }

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -8,8 +8,11 @@ use Zaengle\Audit\MakesAudits;
 class TestModel extends Model
 {
     use MakesAudits;
+
     protected $table = 'test_models';
-    protected $guarded = [];
+
+    protected $fillable = ['name'];
+
     protected $casts = [
         'audits' => 'json',
     ];


### PR DESCRIPTION
This PR adds a couple of enhancements to the audits package. First is a new method that models can use to determine if an audit should run based on a specific set of logic. Secondly, the changes expose a method to manually push data to the audit column on a model without depending on an event hook. Finally, it configurably makes the audits column fillable on models. 

Fixes #4 
Fixes #5 
Fixes #6 